### PR TITLE
feat: Add endpoint to fetch teams by user ID

### DIFF
--- a/apps/backend/src/controllers/team.controller.ts
+++ b/apps/backend/src/controllers/team.controller.ts
@@ -5,6 +5,7 @@ import {
     createTeam,
     fetchTeams,
     fetchTeamByid,
+    fetchTeamsByUserId,
     updateTeam,
     joinUserToTeam,
     removeUserFromTeam,
@@ -171,3 +172,22 @@ export const deleteTeam = async (req: Request, resp: Response) => {
     }
 }
 
+/**
+ * Retrieves the team information associated with a specific user ID.
+ *
+ * @param req - The request object containing the user ID in the parameters.
+ * @param resp - The response object used to send back the HTTP response.
+ *
+ * @returns A JSON response with the team details if successful, or an error message if an error occurs.
+ *
+ * @throws Will return a 500 status code with an error message if an exception is thrown during the process.
+ */
+export const getTeamByUserId = async (req: Request, resp: Response) => {
+    try {
+        const { code, message, details } = await fetchTeamsByUserId(req.params.userId);
+
+        resp.status(code).json({ message, details });
+    } catch (error: any) {
+        resp.status(500).json({ error: error.toString() });
+    }
+}

--- a/apps/backend/src/routers/team.router.ts
+++ b/apps/backend/src/routers/team.router.ts
@@ -5,6 +5,7 @@ import {
     create,
     getTeams,
     getTeamById,
+    getTeamByUserId,
     update,
     addMember,
     removeMember,
@@ -15,6 +16,7 @@ const teamRouter = Router();
 
 teamRouter.get('/', asyncHandler(getTeams));
 teamRouter.get('/:id', asyncHandler(getTeamById));
+teamRouter.get('/user/:userId', asyncHandler(getTeamByUserId));
 teamRouter.post('/', createTeamSchema, asyncHandler(create));
 teamRouter.put('/:id', asyncHandler(update));
 teamRouter.post('/add', asyncHandler(addMember));

--- a/apps/backend/src/services/team.services.ts
+++ b/apps/backend/src/services/team.services.ts
@@ -310,3 +310,47 @@ export const deleteTeamFromStorage = async (id: string) => {
         }
     }
 }
+
+/**
+ * Fetches teams associated with a given user ID.
+ *
+ * @param userId - The ID of the user whose teams are to be fetched.
+ * @returns A promise that resolves to an object containing:
+ * - `code`: The status code of the operation.
+ * - `message`: A message describing the result of the operation.
+ * - `details`: An array of teams if successful, or an error message if not.
+ *
+ * @throws Will return an object with a 500 status code and error details if an exception occurs during the operation.
+ */
+export const fetchTeamsByUserId = async (userId: string) => {
+    try {
+        const teamMembers = await xata.db.TeamMember.filter({ userId }).getAll();
+
+        if (teamMembers.length === 0) {
+            return {
+                code: 400,
+                message: 'Error fetching data!',
+                details: `User with id ${userId} is not a member of any team!`
+            }
+        }
+
+        const teamIds = teamMembers.map((member) => member.teamId.xata_id);
+
+        const teams = await xata.db.Team.filter({
+            xata_id: { $any: teamIds },
+        }).getAll();
+
+        return {
+            code: 200,
+            message: 'Teams fetched successfully',
+            details: teams
+        }
+
+    } catch (error: any) {
+        return {
+            code: 500,
+            message: 'Error fetching teams data!',
+            details: error.toString()
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a new feature to fetch teams associated with a specific user ID. The most important changes include adding a new method to the team controller, updating the team router to handle the new endpoint, and implementing the service function to fetch the teams by user ID.

### New Feature: Fetch Teams by User ID

* [`apps/backend/src/controllers/team.controller.ts`](diffhunk://#diff-c9327bb4f1a659bdfd16e63d4cb396ff1ed4ecaa29248420c6f8b02f9e5d697fR8): Added `fetchTeamsByUserId` to the import statement and implemented the `getTeamByUserId` method to handle the request and response for fetching teams by user ID. [[1]](diffhunk://#diff-c9327bb4f1a659bdfd16e63d4cb396ff1ed4ecaa29248420c6f8b02f9e5d697fR8) [[2]](diffhunk://#diff-c9327bb4f1a659bdfd16e63d4cb396ff1ed4ecaa29248420c6f8b02f9e5d697fR175-R193)

* [`apps/backend/src/routers/team.router.ts`](diffhunk://#diff-696e0b243013c957615da91465c33a1fab3a7fb0fdf6e64cdbda71bb4e9ec22cR8): Updated the router to include a new route `/user/:userId` that maps to the `getTeamByUserId` controller method. [[1]](diffhunk://#diff-696e0b243013c957615da91465c33a1fab3a7fb0fdf6e64cdbda71bb4e9ec22cR8) [[2]](diffhunk://#diff-696e0b243013c957615da91465c33a1fab3a7fb0fdf6e64cdbda71bb4e9ec22cR19)

* [`apps/backend/src/services/team.services.ts`](diffhunk://#diff-b132b05179134e5ee8887bdad6ee1c677a6272f7e4b74414f55c834c37479945R313-R356): Implemented the `fetchTeamsByUserId` service function to query the database for teams associated with a given user ID.

## Route response  via Postman

![image](https://github.com/user-attachments/assets/c0a9d193-7531-4725-b456-c23c4e3d4ebc)
